### PR TITLE
Add md5compute

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ CFLAGS=          -W -Waggregate-return -Wall -Warray-bounds -Wbad-function-cast 
                  -Wunused-parameter -Wunused-value -Wunused-variable -Wvla -Wvolatile-register-var              \
                  -Wwrite-strings -fno-common -fstack-protector-all -pedantic -std=c99 -Wstrict-aliasing=3	
 
-LDFLAGS=-ansi -lpthread -lm -O2 -lcurl
+LDFLAGS=-ansi -lpthread -lm -O2 -lcurl -lcrypto -lssl
 EXEC=pooler
 
 all: $(EXEC)

--- a/config.h
+++ b/config.h
@@ -30,6 +30,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <pthread.h>
+#include <openssl/md5.h>
 
 /* Some constants */
 #define DEBUG_LEVEL	                    5

--- a/config.h
+++ b/config.h
@@ -74,6 +74,13 @@ struct PagePoolingInitData {
 
 typedef struct PagePoolingInitData structPagePoolingInitData;
 
+enum checksumFileAction
+{
+    INIT,
+    UPDATE,
+    CHECK_EXIST,
+    CLOSE
+};
 
 /* Debug part */
 #define UNUSED(x) (void)(x)

--- a/io.c
+++ b/io.c
@@ -255,27 +255,42 @@ int configurationAnalyseLineByLine(char* p_sCompagny)
 
 
 
-
-void updateAndReadChecksumFile(char* p_sName, char* p_sMD5Hash, enum checksumFileAction p_enumAction)
+/**
+ * @brief This function manage all the I/O of a thread to its assigned checksum file.
+ * A checksum file (.md5) hold all md5 of all already known messages, if a md5 isn't here it is
+ * because the message a new one. With this function, you can open the file, check if a md5
+ * is in, append a new md5 at the end and close the file. You have to open the file once, at
+ * the thread's starts and close once too at the thread's closing.
+ * @param p_sName : name of the page pooled by the thread
+ * @param p_sMD5Hash : string with the md5sum in it (already converted in letters. You don't have to put a value when p_enumAction equals INIT or CLOSE
+ * @param p_enumAction : the wanted action, INIT to init the file descriptor etc.. Cf enum checksumFileAction
+ * @return 0 in all cases, and if p_enumAction equals CHECK_EXIST this function returns 1 if the p_sMD5Hash is already in the file and 0 if this p_sMD5Hash is unknown
+ */
+int updateAndReadChecksumFile(char* p_sName, char* p_sMD5Hash, enum checksumFileAction p_enumAction)
 {
     static FILE* l_fileChecksum = NULL;
     static char l_sFileName[MAX_CONFIG_LINE_LEN];
+    char l_sReadLine[34];       /* 33 + 1 EOL */
     int l_iRetCode;
 
     l_iRetCode = 0;
+    bzero(l_sReadLine, 34);
 
     /* If we want to use a un-initialized file */
     if(p_enumAction != INIT && l_fileChecksum == NULL)
     {
         LOG_WARNING("Try to do action %d but no INIT have be done before...", p_enumAction);
-        return;
+        return 0;
     }
 
+
+    /* Classical actions, described in the enum structure */
     switch(p_enumAction)
     {
+        /* To call once at the first usage of this function */
         case INIT:
             snprintf(l_sFileName, MAX_CONFIG_LINE_LEN, "%s/%s.md5", CHECKSUM_DIRECTORY, p_sName);
-            l_fileChecksum = fopen(l_sFileName, "w+");
+            l_fileChecksum = fopen(l_sFileName, "a+");
             if(l_fileChecksum == NULL)
             {
                 LOG_ERROR("File %s impossible to open. No actions on it.", l_sFileName);
@@ -286,15 +301,29 @@ void updateAndReadChecksumFile(char* p_sName, char* p_sMD5Hash, enum checksumFil
             }
             break;
 
+        /* you have to check if the p_sMD5Hash is already present in the file, this action
+         * just append p_sMD5Hash to the end of the file */
         case UPDATE:
             LOG_INFO("Add [%s]", p_sMD5Hash);
+            fseek (l_fileChecksum, 0, SEEK_END);
             fprintf(l_fileChecksum, "%s\n", p_sMD5Hash);
             break;
 
+        /* Check if p_sMD5Hash is already in the file, read all the file. This function may
+         * be greedy, if there is too many disk access we have to fix this FIXME */
         case CHECK_EXIST:
-            /* FIXME */
+            fseek (l_fileChecksum, 0, SEEK_SET);
+            do
+            {
+                fgets(l_sReadLine, MAX_CONFIG_LINE_LEN, l_fileChecksum);
+                if(strstr(l_sReadLine, p_sMD5Hash) != NULL)
+                {
+                    return 1;
+                }
+            }while(!feof(l_fileChecksum));
             break;
 
+        /* Call when the thread is going to close */
         case CLOSE:
             l_iRetCode = fclose(l_fileChecksum);
             if(l_iRetCode != 0)
@@ -307,4 +336,6 @@ void updateAndReadChecksumFile(char* p_sName, char* p_sMD5Hash, enum checksumFil
             LOG_WARNING("This action doen't exist : %d", p_enumAction);
             break;
     }
+
+    return 0;
 }

--- a/io.h
+++ b/io.h
@@ -21,6 +21,7 @@ int createDirectory(const char* p_cName);
 int checkConfigurationFiles(void);
 int initExternalCommunication(void);
 int configurationAnalyseLineByLine(char* p_sCompagny);
+void updateAndReadChecksumFile(char* l_sName, char* p_sMD5Hash, enum checksumFileAction p_enumAction);
 
 
 

--- a/io.h
+++ b/io.h
@@ -21,7 +21,7 @@ int createDirectory(const char* p_cName);
 int checkConfigurationFiles(void);
 int initExternalCommunication(void);
 int configurationAnalyseLineByLine(char* p_sCompagny);
-void updateAndReadChecksumFile(char* l_sName, char* p_sMD5Hash, enum checksumFileAction p_enumAction);
+int updateAndReadChecksumFile(char* l_sName, char* p_sMD5Hash, enum checksumFileAction p_enumAction);
 
 
 

--- a/network.c
+++ b/network.c
@@ -182,14 +182,15 @@ MD5_Final(l_iMD5Output, &l_structMD5Context);
                 sprintf(&l_sMD5Hash[l_iIterator * 2], "%02x", (unsigned int)l_iMD5Output[l_iIterator]);
             }
 
-            LOG_INFO("md5out: %s", l_sMD5Hash);
-
             /*****************
             *
             *  MD5Quote save
             *
             *****************/
-            updateAndReadChecksumFile(l_structInitData->sName, l_sMD5Hash, UPDATE);
+            if(updateAndReadChecksumFile(l_structInitData->sName, l_sMD5Hash, CHECK_EXIST) != 1)
+            {
+                updateAndReadChecksumFile(l_structInitData->sName, l_sMD5Hash, UPDATE);
+            }
 
  
             /*****************

--- a/network.c
+++ b/network.c
@@ -116,7 +116,9 @@ void* threadPagePooling (void* p_structInitData)
     l_sUrl = (char*)malloc(MAX_CONFIG_LINE_LEN * sizeof(char));
     l_sCursor = NULL;
     l_sQuote = NULL;
+
     MD5_Init(&l_structMD5Context);
+    updateAndReadChecksumFile(l_structInitData->sName, NULL, INIT);
 
     if( l_iReturnValue == NULL ||
         l_sUrl == NULL)
@@ -184,6 +186,14 @@ MD5_Final(l_iMD5Output, &l_structMD5Context);
 
             /*****************
             *
+            *  MD5Quote save
+            *
+            *****************/
+            updateAndReadChecksumFile(l_structInitData->sName, l_sMD5Hash, UPDATE);
+
+ 
+            /*****************
+            *
             *  Quote erase
             *
             *****************/
@@ -196,6 +206,7 @@ MD5_Final(l_iMD5Output, &l_structMD5Context);
         LOG_INFO("Page %s NOT retrieved. Network error.", l_sUrl);
     }
 
+    updateAndReadChecksumFile(l_structInitData->sName, NULL, CLOSE);
     *l_iReturnValue = 314;              /* Test value */
 
 


### PR DESCRIPTION
Add md5 compute / check / add function. To avoid to analyse old entries, we compute a hash for each new sentence, and save it in a file. When a new sentence come in, we check if we already know it and then, parse it or not.
